### PR TITLE
Fixes for macos

### DIFF
--- a/lib/App/Rakubrew/Download.pm
+++ b/lib/App/Rakubrew/Download.pm
@@ -31,7 +31,6 @@ sub download_precomp_archive {
         say STDERR "$name is already installed.";
         exit 1;
     }
-    mkdir $name;
 
     my $ht = HTTP::Tinyish->new();
 
@@ -55,6 +54,7 @@ sub download_precomp_archive {
         exit 1;
     }
 
+    mkdir $name;
     say 'Extracting';
     if (_my_platform() eq 'win') {
         _unzip(\($res->{content}), $name);

--- a/lib/App/Rakubrew/Download.pm
+++ b/lib/App/Rakubrew/Download.pm
@@ -107,7 +107,7 @@ sub _retrieve_releases {
 sub _my_platform {
 	my %oses = (
 		MSWin32 => 'win',
-		dawin   => 'macos',
+		darwin  => 'macos',
 		linux   => 'linux',
 		openbsd => 'openbsd',
 	);
@@ -120,7 +120,9 @@ sub _my_arch {
         $Config{archname} =~ /x86_64/i ? 'x86_64' :
         $Config{archname} =~ /amd64/i  ? 'x86_64' :
         $Config{archname} =~ /x86/i    ? 'x86'    :
+        $Config{archname} =~ /darwin/  ? 'x86_64' :
         '';
+
     unless ($arch) {
         say STDERR 'Couldn\'t detect system architecture. Current arch is: ' . $Config{archname};
         exit 1;


### PR DESCRIPTION
This should addresses some errors mentioned in issue #10 

Turns out there are more than just not fully packing HTTPTiny, both the detection of "_my_arch" and "_my_platform" need some patches in order to correctly find a downloadable URL from the index of rakudo builds.

The originaly failure messages is:

```
> perl -Ilib ./script/rakubrew download moar 2020.01
Couldn't detect system architecture. Current arch is: darwin-2level
```

After applying this PR it works:
```
> perl -Ilib ./script/rakubrew download moar 2020.01
Downloading https://rakudo.org/dl/rakudo/rakudo-moar-2020.01-01-macos-x86_64.tar.gz
Extracting
Updating shims
Done, moar-2020.01 installed
```
