### PR TITLE
Add missing import

### DIFF
--- a/lib/App/Rakubrew/Shell/Zsh.pm
+++ b/lib/App/Rakubrew/Shell/Zsh.pm
@@ -4,6 +4,7 @@ our @ISA = "App::Rakubrew::Shell";
 use strict;
 use warnings;
 use 5.010;
+use File::Spec::Functions qw(catfile);
 
 use App::Rakubrew::Variables;
 use App::Rakubrew::Tools;


### PR DESCRIPTION
This resolves below error by `rakubrew init` on zsh.
```
% rakubrew init
Undefined subroutine &App::Rakubrew::Shell::Zsh::catfile called at /<redacted>/App/Rakubrew/Shell/Zsh.pm line 21.
```