### PR TITLE
filter for the backend when downloading precompiled archive

### DIFF
--- a/lib/App/Rakubrew/Download.pm
+++ b/lib/App/Rakubrew/Download.pm
@@ -35,7 +35,7 @@ sub download_precomp_archive {
     my $ht = HTTP::Tinyish->new();
 
     my @matching_releases = grep {
-            $ver ? $_->{ver} eq $ver : $_->{latest}
+            $_->{backend} eq $impl && ($ver ? $_->{ver} eq $ver : $_->{latest})
         } _retrieve_releases($ht);
 
     if (!@matching_releases) {


### PR DESCRIPTION
Currently `rakubrew download jvm 2020.07` happily downloads the MoarVM pre-compiled archive and installs it as `jvm-2020.07`. (Note: This PR will make it error out instead, at least for now, as apparently there are no JVM pre-compiled archives.)