### PR TITLE
Fix completion for Fish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ blib/
 versions/*
 shims/*
 git_reference/
+download/*
+perl-darwin-2level/*
 
 fatpacker.trace
 packlists

--- a/lib/App/Rakubrew.pm
+++ b/lib/App/Rakubrew.pm
@@ -36,7 +36,6 @@ sub run_script {
     my ($self) = @_;
     my @args = @{$self->{args}};
 
-
     sub _cant_access_home {
         say STDERR "Can't create rakubrew home directory in $prefix";
         say STDERR "Probably rakubrew was denied access. You can either change that folder to be writable";

--- a/lib/App/Rakubrew/Shell.pm
+++ b/lib/App/Rakubrew/Shell.pm
@@ -163,7 +163,7 @@ sub get_completions {
     my $index = shift;
     my @words = @_;
 
-    if ($index == 0) {
+    if ($index <= 0) { # if @words is empty then $index == -1
         my @commands = qw(version current versions list global switch shell local nuke unregister rehash list-available build register build-zef download exec which whence mode self-upgrade triple test home rakubrew-version);
         my $candidate = $words[0] // '';
         return grep({ substr($_, 0, length($candidate)) eq $candidate } @commands);

--- a/lib/App/Rakubrew/Shell.pm
+++ b/lib/App/Rakubrew/Shell.pm
@@ -8,6 +8,13 @@ use App::Rakubrew::Tools;
 use App::Rakubrew::Variables;
 use App::Rakubrew::VersionHandling;
 
+# Turn on substring-based command line completion where possible contrary to the
+# "start of the line completion". I.e., to visualize the difference, 'ver'
+# string would result in the following command candidates:
+#   SUBSTRING_COMPLETION==1 -> version versions rakubrew-version
+#   SUBSTRING_COMPLETION==0 -> version versions
+use constant SUBSTRING_COMPLETION => 1;
+
 my $shell_hook;
 
 sub initialize {
@@ -167,44 +174,58 @@ This function takes two parameters:
 
 =over 4
 
-=item * Index of the word to complete (starting at 0)
+=item * Index of the word to complete, 0-based. If C<-1> is passed then list of all commands is returned.
 
 =item * A list of words already entered
 
 =back
 
 =cut
+
+sub _filter_candidates {
+    my $self = shift;
+    my $seed = shift;
+    return 
+        # If a shell preserves ordering then put the prefix-mathing candidates first. I.e. for 'ver' 'version' would
+        # precede 'rakudo-version'
+        sort { index($a, $seed) cmp index($a, $seed) }
+        grep { 
+            my $pos = index($_, $seed);
+            SUBSTRING_COMPLETION ? $pos >= 0 : $pos == 0
+        } @_
+}
+
 sub get_completions {
     my $self = shift;
-    my $index = shift;
-    my @words = @_;
+    my ($index, @words) = @_;
 
     if ($index <= 0) { # if @words is empty then $index == -1
         my @commands = qw(version current versions list global switch shell local nuke unregister rehash list-available build register build-zef download exec which whence mode self-upgrade triple test home rakubrew-version);
-        my $candidate = $words[0] // '';
-        return grep({ substr($_, 0, length($candidate)) eq $candidate } @commands);
+        my $candidate = $index < 0 || !$words[0] ? '' : $words[0];
+        my @c = $self->_filter_candidates($candidate, @commands);
+        return @c;
     }
     elsif($index == 1 && ($words[0] eq 'global' || $words[0] eq 'switch' || $words[0] eq 'shell' || $words[0] eq 'local' || $words[0] eq 'nuke' || $words[0] eq 'test')) {
         my @versions = get_versions();
         push @versions, 'all'     if $words[0] eq 'test';
         push @versions, '--unset' if $words[0] eq 'shell';
         my $candidate = $words[1] // '';
-        return grep({ substr($_, 0, length($candidate)) eq $candidate } @versions);
+        return $self->_filter_candidates($candidate, @versions);
     }
     elsif($index == 1 && $words[0] eq 'build') {
         my $candidate = $words[1] // '';
-        return grep({ substr($_, 0, length($candidate)) eq $candidate } (App::Rakubrew::Build::available_backends(), 'all'));
+        return $self->_filter_candidates($candidate, (App::Rakubrew::Build::available_backends(), 'all'));
     }
     elsif($index == 2 && $words[0] eq 'build') {
         my @installed = get_versions();
         my @installables = grep({ my $x = $_; !grep({ $x eq $_ } @installed) } App::Rakubrew::Build::available_rakudos());
 
         my $candidate = $words[2] // '';
-        return grep({ substr($_, 0, length($candidate)) eq $candidate } @installables);
+        return $self->_filter_candidates($candidate, @installables);
     }
     elsif($index == 1 && $words[0] eq 'download') {
         my $candidate = $words[1] // '';
-        return grep({ substr($_, 0, length($candidate)) eq $candidate } ('moar'));
+        return $self->_filter_candidates($candidate, ('moar'));
     }
     elsif($index == 2 && $words[0] eq 'download') {
         my @installed = get_versions();
@@ -212,12 +233,12 @@ sub get_completions {
         @installables = grep({ my $x = $_; !grep({ $x eq $_ } @installed) } @installables);
 
         my $candidate = $words[3] // '';
-        return grep({ substr($_, 0, length($candidate)) eq $candidate } @installables);
+        return $self->_filter_candidates($candidate, @installables);
     }
     elsif($index == 1 && $words[0] eq 'mode') {
         my @modes = qw(env shim);
         my $candidate = $words[2] // '';
-        return grep({ substr($_, 0, length($candidate)) eq $candidate } @modes);
+        return $self->_filter_candidates($candidate, @modes);
     }
     elsif($index == 2 && $words[0] eq 'register') {
         my @completions;

--- a/lib/App/Rakubrew/Shell.pm
+++ b/lib/App/Rakubrew/Shell.pm
@@ -188,7 +188,7 @@ sub _filter_candidates {
     return 
         # If a shell preserves ordering then put the prefix-mathing candidates first. I.e. for 'ver' 'version' would
         # precede 'rakudo-version'
-        sort { index($a, $seed) cmp index($a, $seed) }
+        sort { index($a, $seed) cmp index($b, $seed) }
         grep { 
             my $pos = index($_, $seed);
             SUBSTRING_COMPLETION ? $pos >= 0 : $pos == 0

--- a/lib/App/Rakubrew/Shell.pm
+++ b/lib/App/Rakubrew/Shell.pm
@@ -144,6 +144,22 @@ sub clean_path {
     return $path;
 }
 
+# Strips out all elements in arguments array up to and including $bre_name
+# command.  The first argument is index where the completion should look for the
+# word to be completed.
+sub strip_executable {
+    my $self = shift;
+    my $index = shift;
+
+    my $cmd_pos = 0;
+    foreach my $word (@_) {
+        ++$cmd_pos;
+        --$index;
+        last if $word =~ /(^|\W)$brew_name$/;
+    }
+    return ($index, @_[$cmd_pos..$#_])
+}
+
 =pod
 
 Returns a list of completion candidates.

--- a/lib/App/Rakubrew/Shell.pm
+++ b/lib/App/Rakubrew/Shell.pm
@@ -214,7 +214,7 @@ sub get_completions {
     }
     elsif($index == 1 && $words[0] eq 'build') {
         my $candidate = $words[1] // '';
-        return $self->_filter_candidates($candidate, (App::Rakubrew::Build::available_backends(), 'all'));
+        return $self->_filter_candidates($candidate, (App::Rakubrew::Variables::available_backends(), 'all'));
     }
     elsif($index == 2 && $words[0] eq 'build') {
         my @installed = get_versions();

--- a/lib/App/Rakubrew/Shell/Bash.pm
+++ b/lib/App/Rakubrew/Shell/Bash.pm
@@ -98,11 +98,7 @@ sub get_shell_unsetter_code {
 sub completions {
     my $self = shift;
     my $index = shift;
-    my @words = @_;
-    shift @words; # remove command name
-
-    my @completions = $self->get_completions($index - 1, @words);
-    say join(' ', @completions);
+    say join(' ', $self->get_completions($self->strip_executable($index - 1, @_)));
 }
 
 sub completion_options {

--- a/lib/App/Rakubrew/Shell/Fish.pm
+++ b/lib/App/Rakubrew/Shell/Fish.pm
@@ -118,7 +118,15 @@ sub completions {
     my $self = shift;
     my @words = @_;
 
-    my @completions = $self->get_completions(@words - 1, @words);
+    my $index = scalar(@words);
+    # Strip command name.
+    while (@words > 0) {
+        my $word = shift @words;
+        $index--;
+        last if $word =~ /(^|\W)$brew_name$/;
+    }
+
+    my @completions = $self->get_completions($index, @words);
     say join(' ', @completions);
 }
 

--- a/lib/App/Rakubrew/Shell/Fish.pm
+++ b/lib/App/Rakubrew/Shell/Fish.pm
@@ -85,7 +85,7 @@ function _${brew_name}_is_not_register
     end
 end
 
-complete -c $brew_name -f -n _${brew_name}_is_not_register -a '(command $brew_exec internal_shell_hook Fish completions (commandline -poc) | string split " ")'
+complete -c $brew_name -f -n _${brew_name}_is_not_register -a '(command $brew_exec internal_shell_hook Fish completions (commandline -poc) (commandline -ct) | string split " ")'
 EOT
 
 }
@@ -116,18 +116,7 @@ sub get_shell_unsetter_code {
 
 sub completions {
     my $self = shift;
-    my @words = @_;
-
-    my $index = scalar(@words);
-    # Strip command name.
-    while (@words > 0) {
-        my $word = shift @words;
-        $index--;
-        last if $word =~ /(^|\W)$brew_name$/;
-    }
-
-    my @completions = $self->get_completions($index, @words);
-    say join(' ', @completions);
+    say join(" ", $self->get_completions($self->strip_executable($#_, @_)));
 }
 
 1;

--- a/lib/App/Rakubrew/Shell/Tcsh.pm
+++ b/lib/App/Rakubrew/Shell/Tcsh.pm
@@ -89,11 +89,10 @@ sub completions {
     my $self = shift;
     my $command = shift;
     my @words = split ' ', $command;
-    shift @words; # remove command name
     my $index = @words - 1;
     $index++ if $command =~ / $/;
 
-    my @completions = $self->get_completions($index, @words);
+    my @completions = $self->get_completions($self->strip_executable($index, @words));
     say join(' ', @completions);
 }
 

--- a/lib/App/Rakubrew/Shell/Zsh.pm
+++ b/lib/App/Rakubrew/Shell/Zsh.pm
@@ -111,18 +111,7 @@ sub get_shell_unsetter_code {
 sub completions {
     my $self = shift;
     my $index = shift;
-    $index--; # We want 0 based
-    my @words = @_;
-
-    # Strip command name.
-    while (@words > 0) {
-        my $word = shift @words;
-        $index--;
-        last if $word =~ /(^|\W)$brew_name$/;
-    }
-
-    my @completions = $self->get_completions($index, @words);
-    say join(' ', @completions);
+    say join(' ', $self->get_completions($self->strip_executable($index - 1, @_)));
 }
 
 1;

--- a/release-stuff/build-macos.sh
+++ b/release-stuff/build-macos.sh
@@ -41,6 +41,7 @@ cd $DIR/..
 
 # Download precompiled perl.
 mkdir download
+unset PERL5LIB
 curl -L -o download/perl-precomp.tar.gz https://github.com/skaji/relocatable-perl/releases/download/5.26.1.1/perl-darwin-2level.tar.gz
 tar -xzf download/perl-precomp.tar.gz
 export PATH=$DIR/../perl-darwin-2level/bin:$PATH

--- a/release-stuff/build-macos.sh
+++ b/release-stuff/build-macos.sh
@@ -40,10 +40,14 @@ DIR=$(dirname -- "$EXEC")
 cd $DIR/..
 
 # Download precompiled perl.
-mkdir download
+if ! [ -d download ]; then
+    mkdir download
+fi
 unset PERL5LIB
-curl -L -o download/perl-precomp.tar.gz https://github.com/skaji/relocatable-perl/releases/download/5.26.1.1/perl-darwin-2level.tar.gz
-tar -xzf download/perl-precomp.tar.gz
+if ! [ -d $DIR/../perl-darwin-2level ]; then
+    curl -L -o download/perl-precomp.tar.gz https://github.com/skaji/relocatable-perl/releases/download/5.26.1.1/perl-darwin-2level.tar.gz
+    tar -xzf download/perl-precomp.tar.gz
+fi
 export PATH=$DIR/../perl-darwin-2level/bin:$PATH
 
 # Prepare Config.pm


### PR DESCRIPTION
The completion is currently plain broken. This PR currently works for me.

Also fixed `build-macos.sh` which doesn't work if `PERL5LIB` shell variable is set due to `cpanm` installing elsewhere but not into the local perl copy. Looks like the same fix would be required for other build scripts but I better don't touch them without trying myself.

And likely a fix for a problem with Zsh.pm which incorrectly expects `$index` as its first argument.