### PR TITLE
Add completion for `help` and `available` commands plus fix Bash completion

### DIFF
--- a/lib/App/Rakubrew/Shell.pm
+++ b/lib/App/Rakubrew/Shell.pm
@@ -199,10 +199,11 @@ sub get_completions {
     my $self = shift;
     my ($index, @words) = @_;
 
+    my @commands = qw(version current versions list global switch shell local nuke unregister rehash available list-available build register build-zef download exec which whence mode self-upgrade triple test home rakubrew-version);
+
     if ($index <= 0) { # if @words is empty then $index == -1
-        my @commands = qw(version current versions list global switch shell local nuke unregister rehash available list-available build register build-zef download exec which whence mode self-upgrade triple test home rakubrew-version);
         my $candidate = $index < 0 || !$words[0] ? '' : $words[0];
-        my @c = $self->_filter_candidates($candidate, @commands);
+        my @c = $self->_filter_candidates($candidate, @commands, 'help');
         return @c;
     }
     elsif($index == 1 && ($words[0] eq 'global' || $words[0] eq 'switch' || $words[0] eq 'shell' || $words[0] eq 'local' || $words[0] eq 'nuke' || $words[0] eq 'test')) {
@@ -258,6 +259,12 @@ sub get_completions {
         }
         closedir $dh;
         return @completions;
+    }
+    elsif($index == 1 && $words[0] eq 'help') {
+        my $candidate = $words[1] // '';
+        my @topics = @commands;
+        push @topics, '--verbose';
+        return $self->_filter_candidates($candidate, @topics);
     }
 }
 

--- a/lib/App/Rakubrew/Shell.pm
+++ b/lib/App/Rakubrew/Shell.pm
@@ -200,7 +200,7 @@ sub get_completions {
     my ($index, @words) = @_;
 
     if ($index <= 0) { # if @words is empty then $index == -1
-        my @commands = qw(version current versions list global switch shell local nuke unregister rehash list-available build register build-zef download exec which whence mode self-upgrade triple test home rakubrew-version);
+        my @commands = qw(version current versions list global switch shell local nuke unregister rehash available list-available build register build-zef download exec which whence mode self-upgrade triple test home rakubrew-version);
         my $candidate = $index < 0 || !$words[0] ? '' : $words[0];
         my @c = $self->_filter_candidates($candidate, @commands);
         return @c;

--- a/lib/App/Rakubrew/Shell/Bash.pm
+++ b/lib/App/Rakubrew/Shell/Bash.pm
@@ -98,7 +98,7 @@ sub get_shell_unsetter_code {
 sub completions {
     my $self = shift;
     my $index = shift;
-    say join(' ', $self->get_completions($self->strip_executable($index - 1, @_)));
+    say join(' ', $self->get_completions($self->strip_executable($index, @_)));
 }
 
 sub completion_options {


### PR DESCRIPTION
This PR contains the following improvements to the completion functionality:

* fixes Bash completion (apparently 9fb2494cc7359c4496e53815f9b415a6b3e2b6fa triggered a bug)
* adds completion for the `available` command
* adds completion for the `help` command (incl. topics)