### PR TITLE
Adds zef version to build, refs #31

### DIFF
--- a/lib/App/Rakubrew.pm
+++ b/lib/App/Rakubrew.pm
@@ -311,14 +311,12 @@ EOL
 
     } elsif ($arg eq 'build-zef') {
         my $version = get_version();
-	my $zef_version = shift(@args);
+        my $zef_version = shift(@args);
         if (!$version) {
-	  say STDERR "$brew_name: No version set.";
-	  exit 1;
-	}
-	if ($zef_version) {
-	  say "Building zef $zef_version";
-	}
+          say STDERR "$brew_name: No version set.";
+          exit 1;
+        }
+	say "Building zef ", $zef_version?$zef_version:"latest";
         App::Rakubrew::Build::build_zef($version, $zef_version);
         # Might have new executables now -> rehash
         rehash();

--- a/lib/App/Rakubrew.pm
+++ b/lib/App/Rakubrew.pm
@@ -311,11 +311,15 @@ EOL
 
     } elsif ($arg eq 'build-zef') {
         my $version = get_version();
+	my $zef_version = shift(@args);
         if (!$version) {
-            say STDERR "$brew_name: No version set.";
-            exit 1;
-        }
-        App::Rakubrew::Build::build_zef($version);
+	  say STDERR "$brew_name: No version set.";
+	  exit 1;
+	}
+	if ($zef_version) {
+	  say "Building zef $zef_version";
+	}
+        App::Rakubrew::Build::build_zef($version, $zef_version);
         # Might have new executables now -> rehash
         rehash();
         say "Done, built zef for $version";

--- a/lib/App/Rakubrew.pm
+++ b/lib/App/Rakubrew.pm
@@ -313,8 +313,8 @@ EOL
         my $version = get_version();
         my $zef_version = shift(@args);
         if (!$version) {
-          say STDERR "$brew_name: No version set.";
-          exit 1;
+            say STDERR "$brew_name: No version set.";
+            exit 1;
         }
         say "Building zef ", $zef_version?$zef_version:"latest";
         App::Rakubrew::Build::build_zef($version, $zef_version);

--- a/lib/App/Rakubrew.pm
+++ b/lib/App/Rakubrew.pm
@@ -316,7 +316,7 @@ EOL
           say STDERR "$brew_name: No version set.";
           exit 1;
         }
-	say "Building zef ", $zef_version?$zef_version:"latest";
+        say "Building zef ", $zef_version?$zef_version:"latest";
         App::Rakubrew::Build::build_zef($version, $zef_version);
         # Might have new executables now -> rehash
         rehash();

--- a/lib/App/Rakubrew/Build.pm
+++ b/lib/App/Rakubrew/Build.pm
@@ -192,15 +192,20 @@ sub build_zef {
     _check_git();
     chdir catdir($versions_dir, $version);
     unless (-d 'zef') {
-        if ( $zef_version ) {
-            run "$GIT clone --depth 1 --branch $zef_version $git_repos{zef}";
-        } else {
-            run "$GIT clone --depth 1 $git_repos{zef}";
-        }
+        run "$GIT clone $git_repos{zef}";
     }
     chdir 'zef';
-    run "$GIT pull -q";
-    run "$GIT checkout";
+    my %tags = map  { chomp($_); $_ => 1 } `$GIT tag`;
+    unless ( $zef_version && $tags{$zef_version} ) {
+        say "Building latest version";
+        $zef_version = '';
+    }
+
+    if ( $zef_version ) {
+        run "$GIT checkout tags/$zef_version";
+    } else {
+        run "$GIT checkout master";
+    }
     run get_raku($version) . " -Ilib bin/zef test .";
     run get_raku($version) . " -Ilib bin/zef --/test --force install .";
 }

--- a/lib/App/Rakubrew/Build.pm
+++ b/lib/App/Rakubrew/Build.pm
@@ -199,7 +199,7 @@ sub build_zef {
     chdir 'zef';
     my %tags = map  { chomp($_); $_ => 1 } `$GIT tag`;
     if ( ($zef_version ne "" ) && !$tags{$zef_version} ) {
-          die "Couldn't find version $zef_version, aborting\n";
+        die "Couldn't find version $zef_version, aborting\n";
     }
 
     if ( $zef_version ) {

--- a/lib/App/Rakubrew/Build.pm
+++ b/lib/App/Rakubrew/Build.pm
@@ -199,7 +199,7 @@ sub build_zef {
     chdir 'zef';
     my %tags = map  { chomp($_); $_ => 1 } `$GIT tag`;
     if ( ($zef_version ne "" ) && !$tags{$zef_version} ) {
-          die "Couldn't find version $zef_version, aborting";
+          die "Couldn't find version $zef_version, aborting\n";
     }
 
     if ( $zef_version ) {

--- a/lib/App/Rakubrew/Build.pm
+++ b/lib/App/Rakubrew/Build.pm
@@ -186,19 +186,23 @@ sub build_triple {
 }
 
 sub build_zef {
-    my $version = shift;
+  my $version = shift;
+  my $zef_version = shift;
 
-    _check_git();
-
-    chdir catdir($versions_dir, $version);
-    unless (-d 'zef') {
-        run "$GIT clone $git_repos{zef}";
+  _check_git();
+  chdir catdir($versions_dir, $version);
+  unless (-d 'zef') {
+    if ( $zef_version ) {
+      run "$GIT clone --depth 1 --branch $zef_version $git_repos{zef}";
+    } else {
+      run "$GIT clone --depth 1 $git_repos{zef}";
     }
-    chdir 'zef';
-    run "$GIT pull -q";
-    run "$GIT checkout";
-    run get_raku($version) . " -Ilib bin/zef test .";
-    run get_raku($version) . " -Ilib bin/zef --/test --force install .";
+  }
+  chdir 'zef';
+  run "$GIT pull -q";
+  run "$GIT checkout";
+  run get_raku($version) . " -Ilib bin/zef test .";
+  run get_raku($version) . " -Ilib bin/zef --/test --force install .";
 }
 
 sub _update_git_reference {

--- a/lib/App/Rakubrew/Build.pm
+++ b/lib/App/Rakubrew/Build.pm
@@ -186,23 +186,23 @@ sub build_triple {
 }
 
 sub build_zef {
-  my $version = shift;
-  my $zef_version = shift;
+    my $version = shift;
+    my $zef_version = shift;
 
-  _check_git();
-  chdir catdir($versions_dir, $version);
-  unless (-d 'zef') {
-    if ( $zef_version ) {
-      run "$GIT clone --depth 1 --branch $zef_version $git_repos{zef}";
-    } else {
-      run "$GIT clone --depth 1 $git_repos{zef}";
+    _check_git();
+    chdir catdir($versions_dir, $version);
+    unless (-d 'zef') {
+        if ( $zef_version ) {
+            run "$GIT clone --depth 1 --branch $zef_version $git_repos{zef}";
+        } else {
+            run "$GIT clone --depth 1 $git_repos{zef}";
+        }
     }
-  }
-  chdir 'zef';
-  run "$GIT pull -q";
-  run "$GIT checkout";
-  run get_raku($version) . " -Ilib bin/zef test .";
-  run get_raku($version) . " -Ilib bin/zef --/test --force install .";
+    chdir 'zef';
+    run "$GIT pull -q";
+    run "$GIT checkout";
+    run get_raku($version) . " -Ilib bin/zef test .";
+    run get_raku($version) . " -Ilib bin/zef --/test --force install .";
 }
 
 sub _update_git_reference {

--- a/lib/App/Rakubrew/Build.pm
+++ b/lib/App/Rakubrew/Build.pm
@@ -191,14 +191,15 @@ sub build_zef {
 
     _check_git();
     chdir catdir($versions_dir, $version);
-    unless (-d 'zef') {
+    if (-d 'zef') {
+        run "$GIT checkout master && $GIT pull -q";
+    } else {
         run "$GIT clone $git_repos{zef}";
     }
     chdir 'zef';
     my %tags = map  { chomp($_); $_ => 1 } `$GIT tag`;
-    unless ( $zef_version && $tags{$zef_version} ) {
-        say "Building latest version";
-        $zef_version = '';
+    if ( ($zef_version ne "" ) && !$tags{$zef_version} ) {
+          die "Couldn't find version $zef_version, aborting";
     }
 
     if ( $zef_version ) {


### PR DESCRIPTION
Creates a new argument to `build-zef` that, when present, downloads the specific version of zef, and installs that one instead of the last one, which is the one built-now.
When accepted (and after adding it to the docs) closes #31 