### PR TITLE
Use `-I.` instead of `-Ilib`

### DIFF
--- a/lib/App/Rakubrew/Build.pm
+++ b/lib/App/Rakubrew/Build.pm
@@ -213,8 +213,8 @@ sub build_zef {
     } else {
         run "$GIT checkout master";
     }
-    run get_raku($version) . " -Ilib bin/zef test .";
-    run get_raku($version) . " -Ilib bin/zef --/test --force install .";
+    run get_raku($version) . " -I. bin/zef test .";
+    run get_raku($version) . " -I. bin/zef --/test --force install .";
 }
 
 sub _update_git_reference {


### PR DESCRIPTION
Its probably fine either way, but technically the former is better than the later. For instance older perl6 executables that do not understand the `.rakumod` extension won't be able to discover such modules with `-Ilib` whereas `-I.` explicitly adds any files in the META6.json regardless of their extension.