### PR TITLE
branch references should be to "main"

### DIFF
--- a/lib/App/Rakubrew/Variables.pm
+++ b/lib/App/Rakubrew/Variables.pm
@@ -68,7 +68,7 @@ our %impls = (
     'moar-blead' => {
         name      => "moar-blead",
         weight    => 35,
-        configure => "$PERL5 Configure.pl --backends=moar --gen-moar=master --gen-nqp=master --make-install",
+        configure => "$PERL5 Configure.pl --backends=moar --gen-moar=main --gen-nqp=main --make-install",
         need_repo => ['rakudo', 'nqp', 'MoarVM'],
     },
 );

--- a/script/rakubrew
+++ b/script/rakubrew
@@ -157,7 +157,7 @@ The backend
 
 =item *
 
-C<moar-blead> is the moar and nqp backends at the master branch.
+C<moar-blead> is the moar and nqp backends at the main branch.
 
 =item *
 


### PR DESCRIPTION
Update code and documentation to reflect use of `main` branch, instead of `master`, for moar and nqp