### PR TITLE
Implementing version toggling with `rakubrew switch`

### DIFF
--- a/lib/App/Rakubrew.pm
+++ b/lib/App/Rakubrew.pm
@@ -116,12 +116,17 @@ EOL
 
     } elsif ($arg eq 'global' || $arg eq 'switch') {
         if (!@args) {
-            my $version = get_global_version();
-            if ($version) {
-                say $version;
+            if ($arg eq 'switch') {
+                toggle_global_version();
             }
             else {
-                say "$brew_name: no global version configured";
+                my $version = get_global_version();
+                if ($version) {
+                    say $version;
+                }
+                else {
+                    say "$brew_name: no global version configured";
+                }
             }
         }
         else {

--- a/lib/App/Rakubrew/VersionHandling.pm
+++ b/lib/App/Rakubrew/VersionHandling.pm
@@ -143,6 +143,9 @@ sub set_global_version {
     my $version = shift;
     my $silent = shift;
     verify_version($version);
+    my $last = -e catfile($prefix, 'CURRENT') ? slurp(catfile($prefix, 'CURRENT')) : 'system';
+    chomp $last;
+    spurt(catfile($prefix, 'LAST'), $last);
     say "Switching to $version" unless $silent;
     spurt(catfile($prefix, 'CURRENT'), $version);
 }

--- a/lib/App/Rakubrew/VersionHandling.pm
+++ b/lib/App/Rakubrew/VersionHandling.pm
@@ -11,7 +11,7 @@ our @EXPORT = qw(
     get_version_path clean_version_path
     get_shell_version
     get_local_version set_local_version
-    get_global_version set_global_version
+    get_global_version set_global_version toggle_global_version
     set_brew_mode get_brew_mode get_brew_mode_shell validate_brew_mode
     get_raku
     which whence
@@ -148,6 +148,12 @@ sub set_global_version {
     spurt(catfile($prefix, 'LAST'), $last);
     say "Switching to $version" unless $silent;
     spurt(catfile($prefix, 'CURRENT'), $version);
+}
+
+sub toggle_global_version {
+    my $last =  slurp(catfile($prefix, 'LAST'));
+    chomp $last;
+    set_global_version($last);
 }
 
 sub get_version {


### PR DESCRIPTION
... and `rakubrew switch` only, not `rakubrew global`. This sounded more sane.

Hello,

today is the day I worked on this feature that I proposed in https://github.com/Raku/App-Rakubrew/issues/67. This interface seemed simple and sensible to me. Please keep in mind that I know basically no Perl whatsoever, I just did what seemed to make sense, and then I tested it with going back and forth between my working rakubrew installation + env mode and my local rakubrew script + shim mode 🤣Well, once I understood what was going on, it seemed to work alright.  
Anyway, my point is that I'd really just like to have this feature and provided some quirky code that seems to do it. Please make of it what you wish/can.

Thank you.