### PR TITLE
Enable building of arm64 rakudos on Apple silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ shims/*
 git_reference/
 download/*
 strawberry/*
-perl-darwin-2level/*
+perl-darwin-*/*
 
 fatpacker.trace
 packlists

--- a/release-stuff/build-macos.sh
+++ b/release-stuff/build-macos.sh
@@ -33,6 +33,12 @@ rreadlink() (
 EXEC=$(rreadlink "$0")
 DIR=$(dirname -- "$EXEC")
 
+ARCH=$(uname -m)
+if [[ $ARCH != "arm64" ]]; then
+  # ARCH is probably x86_64 here, but the download links for that arch
+  # contain the string 'amd64'.
+  ARCH="amd64"
+fi
 
 # ============================================
 # Actual script starts here
@@ -44,11 +50,11 @@ if ! [ -d download ]; then
     mkdir download
 fi
 unset PERL5LIB
-if ! [ -d $DIR/../perl-darwin-2level ]; then
-    curl -L -o download/perl-precomp.tar.gz https://github.com/skaji/relocatable-perl/releases/download/5.26.1.1/perl-darwin-2level.tar.gz
+if ! [ -d $DIR/../perl-darwin-$ARCH ]; then
+    curl -L -o download/perl-precomp.tar.gz https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-$ARCH.tar.gz
     tar -xzf download/perl-precomp.tar.gz
 fi
-export PATH=$DIR/../perl-darwin-2level/bin:$PATH
+export PATH=$DIR/../perl-darwin-$ARCH/bin:$PATH
 
 # Prepare Config.pm
 cp resources/Config.pm.tmpl lib/App/Rakubrew/Config.pm


### PR DESCRIPTION
Previously the macos rakubrew was build with a x86 perl, which resulted in a x86 rakubrew and ultimately an x86 rakudo. This updates the macos build script to detect arm64 systems and to download the appropriate perl, build an arm64 rakubrew, which itself will build arm64 rakudos.

This also updates the version of perl used to one that has an arm build available.